### PR TITLE
Obj updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,6 @@ To generate documentation, add `-DBUILD_DOC=ON` to cmake call. Additional depend
 To include in a CMake project:
 
 ```bash
-find_package(APTracer 1.3.0 REQUIRED)
+find_package(APTracer 1.3.1 REQUIRED)
 target_link_libraries(example APTracer::APTracer)
 ```

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,7 +23,7 @@ copyright = "2021, Guillaume Tousignant"
 author = "Guillaume Tousignant"
 
 # The full version, including alpha/beta/rc tags
-release = "1.3.0"
+release = "1.3.1"
 
 
 # -- General configuration ---------------------------------------------------

--- a/include/entities/TransformMatrix_t.hpp
+++ b/include/entities/TransformMatrix_t.hpp
@@ -53,7 +53,7 @@ namespace APTracer { namespace Entities {
              *
              * @param values Array containing the elements of the matrix, ordered by rows.
              */
-            TransformMatrix_t(std::array<double, size_> values);
+            explicit TransformMatrix_t(std::array<double, size_> values);
 
             std::array<double, size_> matrix_; /**< @brief Array of the 16 values in the 4x4 matrix.*/
             std::array<double, size_> matrix_inverse_; /**< @brief Transposed inverted matrix, used to transform directions.*/
@@ -267,5 +267,14 @@ namespace APTracer { namespace Entities {
             auto buildInverse() -> void;
     };
 }}
+
+/**
+ * @brief Formats a transformation matrix to be displayed.
+ *
+ * @param output Output stream.
+ * @param m Transformation matrix to be displayed.
+ * @return std::ostream& Output stream.
+ */
+auto operator<<(std::ostream& output, const APTracer::Entities::TransformMatrix_t& m) -> std::ostream&;
 
 #endif

--- a/scenes/dragon.xml
+++ b/scenes/dragon.xml
@@ -11,7 +11,7 @@
         <material colour="grey1" emission="black" name="difgrey" roughness="1" type="diffuse"/>
         <material colour="grey2" emission="black" name="difgrey2" roughness="1" type="diffuse"/>
         <material colour="1 1 1" emission="black" name="dragonmat" roughness="1" texture="1" type="diffuse"/>
-        <material colour="white" diffusivity="1" emission="black" name="air2" order="1" medium="air2_scatterer" type="reflective_refractive_fuzz"/>
+        <material name="smoke" medium="air2_scatterer" type="transparent"/>
         <material colour="white" emission="black" name="glass" medium="glass_absorber" type="reflective_refractive"/>
         <material colour="white" emission="black" name="jade" medium="jade_scatterer" type="reflective_refractive"/>
         <material colour="white" emission="black" name="emissive" medium="emissive_scatterer" type="reflective_refractive"/>
@@ -27,7 +27,7 @@
                 <transformation_pre type="rotatezaxis" value="3.1416"/>
             </transformations_pre>
         </object>
-        <object material="jade" mesh_geometry="dragon_mesh" name="dragon" transform_matrix="NaN" type="mesh_motionblur">
+        <object material="smoke" mesh_geometry="dragon_mesh" name="dragon" transform_matrix="NaN" type="mesh_motionblur">
             <transformations_pre>
                 <transformation_pre type="translate" value="0 0 0"/>
                 <transformation_pre type="uniformscale" value="1"/>

--- a/scenes/dragon.xml
+++ b/scenes/dragon.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<scene name="dragon">
+    <mediums>
+        <medium name="air" type="nonabsorber" ind="1.001" priority="0"/>
+    </mediums>
+    <materials>
+        <material colour="grey1" emission="black" name="difgrey" roughness="1" type="diffuse"/>
+        <material colour="grey2" emission="black" name="difgrey2" roughness="1" type="diffuse"/>
+        <material colour="1 1 1" emission="black" name="dragonmat" roughness="1" texture="1" type="diffuse"/>
+    </materials>
+    <objects>
+        <object material="difgrey" name="planegrey1" normals="NaN" points="-2 4 -0.5&#xA;-2 -4 -0.5&#xA; 2 -4 -0.5" texture_coordinates="NaN" transform_matrix="NaN" type="triangle">
+            <transformations_pre>
+                <transformation_pre type="rotatezaxis" value="3.1416"/>
+            </transformations_pre>
+        </object>
+        <object material="difgrey" name="planegrey2" normals="NaN" points="-2 4 -0.5&#xA; 2 -4 -0.5&#xA; 2 4 -0.5" texture_coordinates="NaN" transform_matrix="NaN" type="triangle">
+            <transformations_pre>
+                <transformation_pre type="rotatezaxis" value="3.1416"/>
+            </transformations_pre>
+        </object>
+        <object material="dragonmat" mesh_geometry="dragon_mesh" name="dragon" transform_matrix="NaN" type="mesh_motionblur">
+            <transformations_pre>
+                <transformation_pre type="translate" value="0 0 0"/>
+                <transformation_pre type="uniformscale" value="1"/>
+                <transformation_pre type="rotatex" value="1.5707963"/>
+                <transformation_pre type="rotatez" value="-1"/>
+                <transformation_pre type="rotatezaxis" value="0"/>
+            </transformations_pre>
+        </object>
+    </objects>
+    <skyboxes>
+        <skybox light_colour="12.6373 11.9395 11.6477" light_position="0.62093 0.77075" light_radius="0.035" name="beach" texture="beach_texture" type="skybox_texture_sun"/>
+    </skyboxes>
+    <imgbuffers>
+        <imgbuffer name="buffer" resx="3000" resy="2000" type="imgbuffer_opengl"/>
+    </imgbuffers>
+    <cameras>
+        <camera aperture="0.005" filename="NaN" focus_distance="NaN" focus_position="0.5 0.5" fov="0.93084 1.3963" gammaind="1" imgbuffer="1" max_bounces="8" medium_list="air, air" n_iter="Inf" name="camera1" rendermode="accumulation" write_interval="500" skybox="1" subpix="1 1" transform_matrix="NaN" type="cam_aperture" up="0 0 1">
+            <transformations_pre>
+                <transformation_pre type="translate" value="0 -1 0"/>
+                <transformation_pre type="rotatezaxis" value="3.1416"/>
+            </transformations_pre>
+        </camera>
+    </cameras>
+    <textures>
+        <texture filename="assets/Ocean from horn.jpg" name="beach_texture" type="texture"/>
+    </textures>
+    <mesh_geometries>
+        <mesh_geometry filename="assets/dragon.obj" name="dragon_mesh" type="mesh_geometry"/>
+    </mesh_geometries>
+    <acceleration_structures>
+        <acceleration_structure type="multi_grid_vector" min_resolution="1" max_resolution="128" max_cell_content="32" max_grid_level="1"/>
+    </acceleration_structures>
+</scene>

--- a/scenes/dragon.xml
+++ b/scenes/dragon.xml
@@ -2,11 +2,19 @@
 <scene name="dragon">
     <mediums>
         <medium name="air" type="nonabsorber" ind="1.001" priority="0"/>
+        <medium absorption_distance="10000" colour="white" emission="black" emission_distance="10000" name="air2_scatterer" scattering_distance="0.5" type="scatterer" ind="1.01" priority="10"/>
+        <medium absorption_distance="100" colour="teal" emission="black" emission_distance="100" name="glass_absorber" type="absorber" ind="1.5" priority="20"/>
+        <medium absorption_distance="0.05" colour="green" emission="black" emission_distance="10000" name="jade_scatterer" scattering_distance="0.01" type="scatterer" ind="1.7" priority="30"/>
+        <medium absorption_distance="0.5" colour="black" emission="green" emission_distance="0.5" name="emissive_scatterer" scattering_distance="0.05" type="scatterer" ind="1.3" priority="30"/>
     </mediums>
     <materials>
         <material colour="grey1" emission="black" name="difgrey" roughness="1" type="diffuse"/>
         <material colour="grey2" emission="black" name="difgrey2" roughness="1" type="diffuse"/>
         <material colour="1 1 1" emission="black" name="dragonmat" roughness="1" texture="1" type="diffuse"/>
+        <material colour="white" diffusivity="1" emission="black" name="air2" order="1" medium="air2_scatterer" type="reflective_refractive_fuzz"/>
+        <material colour="white" emission="black" name="glass" medium="glass_absorber" type="reflective_refractive"/>
+        <material colour="white" emission="black" name="jade" medium="jade_scatterer" type="reflective_refractive"/>
+        <material colour="white" emission="black" name="emissive" medium="emissive_scatterer" type="reflective_refractive"/>
     </materials>
     <objects>
         <object material="difgrey" name="planegrey1" normals="NaN" points="-2 4 -0.5&#xA;-2 -4 -0.5&#xA; 2 -4 -0.5" texture_coordinates="NaN" transform_matrix="NaN" type="triangle">
@@ -19,7 +27,7 @@
                 <transformation_pre type="rotatezaxis" value="3.1416"/>
             </transformations_pre>
         </object>
-        <object material="dragonmat" mesh_geometry="dragon_mesh" name="dragon" transform_matrix="NaN" type="mesh_motionblur">
+        <object material="jade" mesh_geometry="dragon_mesh" name="dragon" transform_matrix="NaN" type="mesh_motionblur">
             <transformations_pre>
                 <transformation_pre type="translate" value="0 0 0"/>
                 <transformation_pre type="uniformscale" value="1"/>
@@ -36,7 +44,7 @@
         <imgbuffer name="buffer" resx="3000" resy="2000" type="imgbuffer_opengl"/>
     </imgbuffers>
     <cameras>
-        <camera aperture="0.005" filename="NaN" focus_distance="NaN" focus_position="0.5 0.5" fov="0.93084 1.3963" gammaind="1" imgbuffer="1" max_bounces="8" medium_list="air, air" n_iter="Inf" name="camera1" rendermode="accumulation" write_interval="500" skybox="1" subpix="1 1" transform_matrix="NaN" type="cam_aperture" up="0 0 1">
+        <camera aperture="0.005" filename="NaN" focus_distance="NaN" focus_position="0.5 0.5" fov="0.93084 1.3963" gammaind="1" imgbuffer="1" max_bounces="8" medium_list="air, air" n_iter="10000" name="camera1" rendermode="accumulation_write" write_interval="500" skybox="1" subpix="1 1" transform_matrix="NaN" type="cam_aperture" up="0 0 1">
             <transformations_pre>
                 <transformation_pre type="translate" value="0 -1 0"/>
                 <transformation_pre type="rotatezaxis" value="3.1416"/>

--- a/src/entities/TransformMatrix_t.cpp
+++ b/src/entities/TransformMatrix_t.cpp
@@ -527,4 +527,11 @@ auto TransformMatrix_t::buildInverse() -> void {
     }
 }
 
+auto operator<<(std::ostream& output, const TransformMatrix_t& m) -> std::ostream& {
+    output << '[' << m.matrix_[0] << ", " << m.matrix_[1] << ", " << m.matrix_[2] << ", " << m.matrix_[3] << "; " << m.matrix_[4] << ", " << m.matrix_[5] << ", " << m.matrix_[6] << ", "
+           << m.matrix_[7] << "; " << m.matrix_[8] << ", " << m.matrix_[9] << ", " << m.matrix_[10] << ", " << m.matrix_[11] << "; " << m.matrix_[12] << ", " << m.matrix_[13] << ", " << m.matrix_[14]
+           << ", " << m.matrix_[15] << ']';
+    return output;
+}
+
 // NOLINTEND(cppcoreguidelines-avoid-magic-numbers, readability-magic-numbers)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,7 +17,7 @@ auto main(int argc, char** argv) -> int {
             return 0;
         }
         if (input_parser.cmdOptionExists("--version") || input_parser.cmdOptionExists("-v")) {
-            std::cout << "another_path_tracer.exe 1.3.0" << std::endl;
+            std::cout << "another_path_tracer.exe 1.3.1" << std::endl;
             return 0;
         }
 

--- a/src/materials/Scatterer_t.cpp
+++ b/src/materials/Scatterer_t.cpp
@@ -8,8 +8,8 @@ using APTracer::Entities::Vec3f;
 
 APTracer::Materials::Scatterer_t::Scatterer_t(Entities::Vec3f emi_vol, Entities::Vec3f col_vol, double abs_dist_emi, double abs_dist_col, double scat_dist, double ind, unsigned int priority) :
         Medium_t(ind, priority),
-        emission_vol_(-col_vol.ln() / abs_dist_col),
-        colour_vol_(emi_vol * emi_vol / abs_dist_emi /*CHECK probably not right.*/),
+        emission_vol_(emi_vol * emi_vol / abs_dist_emi /*CHECK probably not right.*/),
+        colour_vol_(-col_vol.ln() / abs_dist_col),
         scattering_coefficient_(1.0 / scat_dist),
         unif_(0.0, 1.0) {}
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,7 +11,8 @@ include(CTest)
 include(Catch)
 
 add_executable(unit_tests 
-    example_test.cpp)
+    example_test.cpp
+    TransformMatrix_t_test.cpp)
 target_link_libraries(unit_tests PRIVATE 
     APTracer
     Catch2::Catch2WithMain)

--- a/tests/TransformMatrix_t_test.cpp
+++ b/tests/TransformMatrix_t_test.cpp
@@ -1,0 +1,38 @@
+#include "entities/TransformMatrix_t.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <iostream>
+
+TEST_CASE("TransformMatrix_t()", "Proves that the default constructor correctly creates an identity matrix") {
+    const APTracer::Entities::TransformMatrix_t transform_matrix{};
+
+    REQUIRE(transform_matrix.matrix_[0] == 1.0);
+    REQUIRE(transform_matrix.matrix_[1] == 0.0);
+    REQUIRE(transform_matrix.matrix_[2] == 0.0);
+    REQUIRE(transform_matrix.matrix_[3] == 0.0);
+    REQUIRE(transform_matrix.matrix_[4] == 0.0);
+    REQUIRE(transform_matrix.matrix_[5] == 1.0);
+    REQUIRE(transform_matrix.matrix_[6] == 0.0);
+    REQUIRE(transform_matrix.matrix_[7] == 0.0);
+    REQUIRE(transform_matrix.matrix_[8] == 0.0);
+    REQUIRE(transform_matrix.matrix_[9] == 0.0);
+    REQUIRE(transform_matrix.matrix_[10] == 1.0);
+    REQUIRE(transform_matrix.matrix_[11] == 0.0);
+    REQUIRE(transform_matrix.matrix_[12] == 0.0);
+    REQUIRE(transform_matrix.matrix_[13] == 0.0);
+    REQUIRE(transform_matrix.matrix_[14] == 0.0);
+    REQUIRE(transform_matrix.matrix_[15] == 1.0);
+}
+
+TEST_CASE("scale(0.2) getScale()", "Proves that a scaled matrix returns the correct scale") {
+    APTracer::Entities::TransformMatrix_t transform_matrix;
+    transform_matrix.scale(0.2);
+
+    REQUIRE(transform_matrix.getScale() == 0.2);
+}
+
+TEST_CASE("scaleAxis(0.2) getScale()", "Proves that an axis scaled matrix returns the correct scale") {
+    APTracer::Entities::TransformMatrix_t transform_matrix;
+    transform_matrix.scaleAxis(0.2);
+
+    REQUIRE(transform_matrix.getScale() == 0.2);
+}


### PR DESCRIPTION
## Motivation
<!--- Change type can be FEATURE, MAINTENANCE, BUGFIX, ENVIRONMENTAL, etc. -->
<!--- Motivation should explain why the change is needed, possibly linking to an issue. -->
<!--- Goals should explain what should be changed. -->

| Change type | Motivation | Goals |
| ----------- | ---------- | ----- |
|FEATURE|`obj` files can have negative indices|Support negative indices|
|BUGFIX|`obj` files have issues if empty lines are present|Support empty lines|
|BUGFIX|Scatterer medium has its emission and colour switched|Fix|

## Implementation
<!--- Change refers to a specific change. -->
<!--- Design explains how the change is implemented. -->
<!--- Testing describes how the change was tested. -->

| Change | Design | Testing |
| ------ | ------ | ------- |
|Negative indices|Negative indices countdown from the last entered vertex, normal, or texture coordinate. Who thought this was a good idea? This is crazy. Also this means either using a signed index or looking for a `-` character at the start|`dragon.xml` scene uses a mesh with negative indices and works|
|Blank lines|Blank lines are skipped and no longer create an extra item. The extra item never showed up since its index was never used. However, this silent bug got unearthed by the negative indices, because now every index was shifted by one, breaking everything.|`dragon.xml` scene uses a mesh with blank lines and works|
|Scatterer medium|Dumb copy-paste error when implementing `clang-tidy` fixed. Other mediums are unaffected. Unit tests would have helped a lot here!|Now works|

## Testing
<!--- Please describe in detail how you tested your changes. -->
<!--- Add screenshots if necessary. -->

This mesh has negative indices, blank lines. Here it is rendered with a very weak scatterer destined to mimic fog or smoke:

![dragon006-min](https://github.com/user-attachments/assets/203e614b-53e6-4391-827b-5780d76a7f0b)

Here is the same mesh with an absorptive scatterer and a reflective-refractive surface, to mimic jade:
 
![dragon005-min](https://github.com/user-attachments/assets/e284d328-f927-4cbd-a5c7-94ce83768d16)

And finally here is the same mesh with an emissive scatterer and a reflective-refractive surface, to mimic some kind of glowing glass:

![dragon004-min](https://github.com/user-attachments/assets/1d9ea8a1-d026-4036-bc98-d48289ef5929)

Note how now all materials look as expected.